### PR TITLE
fix: arreglo bug centro-leche no cambiando haciendo click con obturación

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -103,7 +103,7 @@
 }
 
 .click-blue {
-    background-color: blue;
+    background-color: blue !important;
 }
 
 .click-delete {


### PR DESCRIPTION
Al tratar de seleccionar la pieza central de los dientes de leches con Obturación, si bien se añade la clase, no cambia de color, ya que click-blue no tenia la potestad para hacer un override del color de la clase centro-leche, a diferencia de click-red que si lo tiene. 
Esto soluciona ese pequeño detalle, al añadir !important a la clase de click-blue, justo como click-red lo tiene.